### PR TITLE
Fix typespec for Apoc.AES.decrypt/2

### DIFF
--- a/lib/apoc/aes.ex
+++ b/lib/apoc/aes.ex
@@ -76,7 +76,7 @@ defmodule Apoc.AES do
   {:ok, plaintext} = Apoc.AES.decrypt(ciphertext, key)
   ```
   """
-  @spec decrypt(String.t, aes_key) :: binary
+  @spec decrypt(String.t, aes_key) :: {:ok, binary} | :error
   def decrypt(payload, key) do
     {:ok, <<aad::binary-9, iv::binary-16, tag::binary-16, ct::binary>>} = Apoc.decode(payload)
     do_decrypt(ct, aad, iv, tag, key)


### PR DESCRIPTION
This PR updates the typespec for `Apoc.AES.decrypt/2` to match the return value here: https://github.com/coderdan/apoc/blob/bcd4dde06d418769a5bf9daf6fc92fd2a0902aec/lib/apoc/aes.ex#L95-L99

This fixes the `Invalid type specification for function 'Elixir.Apoc.AES':decrypt/2` warning from Dialyzer.